### PR TITLE
PKG-8509: Move doctest to the main channel

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-upload_channels:
-  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
     sha256: 6745e17682d6e2be1ea31ec8bf1814a3d7cb17d61d120e5f2ee5a075926634ad
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
[PKG-8509](https://anaconda.atlassian.net/browse/PKG-8509)

Moving pkg to the main to unvendor doctest in ccache:
https://github.com/AnacondaRecipes/ccache-feedstock/pull/8

[PKG-8509]: https://anaconda.atlassian.net/browse/PKG-8509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ